### PR TITLE
V3.6+ nob

### DIFF
--- a/bound/UpperBound_A.v
+++ b/bound/UpperBound_A.v
@@ -1576,7 +1576,7 @@ i. des_safe. inv H0. unfold is_call_cont_strong. auto. }
           esplits; et.
           econs 3; et.
         (* bsim *)
-        - i. ss. des_ifs. clear_tac.
+        - i. left. ss. des_ifs. clear_tac.
           inv STEPTGT; swap 2 3.
           { contradict NCALLTGT. rr. et. }
           { contradict NRETTGT. rr. et. }
@@ -1598,7 +1598,7 @@ i. des_safe. inv H0. unfold is_call_cont_strong. auto. }
           i. des.
           exists t. eexists. econs. ss. eauto.
         (* bsim *)
-        - i. ss. rewrite LINKTGT in *. ss. clear_tac.
+        - i. left. ss. rewrite LINKTGT in *. ss. clear_tac.
           inv STEPTGT; swap 2 3.
           { contradict NCALLTGT. rr. et. }
           { contradict NRETTGT. rr. et. }
@@ -1631,7 +1631,7 @@ i. des_safe. inv H0. unfold is_call_cont_strong. auto. }
             ss. clarify. exploit same_prog. eapply H. eapply ISFOCTGT. eauto. eauto. eauto. }
           subst. eauto. }
       { i. inv FINALTGT. }
-      i. inv STEPTGT. ss.
+      i. left. inv STEPTGT. ss.
       exploit msfind_bsim; et.
       { des_ifs. eauto. } i; des.
       + des_ifs. esplits; eauto.

--- a/bound/UpperBound_B.v
+++ b/bound/UpperBound_B.v
@@ -1251,7 +1251,7 @@ Section PRESERVATION.
     - right. econs; i; ss.
       + econs; i.
         (* step *)
-        * inv MTCHST; cycle 1.
+        * left. inv MTCHST; cycle 1.
           { inv INITTGT. }
           inv STEPTGT; ss.
           (* step_call *)

--- a/common/BehaviorsC.v
+++ b/common/BehaviorsC.v
@@ -82,7 +82,7 @@ Proof.
       apply Classical_Pred_Type.not_all_ex_not in H0. des.
       repeat (apply_all_once Classical_Prop.imply_to_and; des).
       apply Classical_Prop.not_or_and in H1. des.
-      econs 4; eauto.
+      econs 5; eauto; ss.
       ii. eapply H2; eauto.
     - eapply behavior_improves_bot; eauto.
   }

--- a/compose/ModTuple.v
+++ b/compose/ModTuple.v
@@ -1885,7 +1885,7 @@ Module ModTuple.
                 { econs; et. econs; et. }
                 intro T; des. esplits; eauto. eapply star_refl.
               + (* bsim *)
-                inv STEPTGT; swap 2 3.
+                left. inv STEPTGT; swap 2 3.
                 { contradict NCALLTGT. rr. et. }
                 { contradict NRETTGT. rr. et. }
                 esplits; eauto.
@@ -1918,7 +1918,7 @@ Module ModTuple.
                   { econs; et. econs; et. econs; et. }
                   intro T; des. esplits; eauto. eapply star_refl.
                 + (* bsim *)
-                  inv STEPTGT; swap 2 3.
+                  left. inv STEPTGT; swap 2 3.
                   { contradict NCALLTGT. rr. et. }
                   { contradict NRETTGT. rr. et. }
                   esplits; eauto.
@@ -1952,7 +1952,7 @@ Module ModTuple.
                   { econs; et. econs; et. econs; et. }
                   intro T; des. esplits; eauto. eapply star_refl.
                 + (* bsim *)
-                  inv STEPTGT; swap 2 3.
+                  left. inv STEPTGT; swap 2 3.
                   { contradict NCALLTGT. rr. et. }
                   { contradict NRETTGT. rr. et. }
                   esplits; eauto.
@@ -2033,7 +2033,7 @@ Module ModTuple.
           { (* BSIM *)
             repeat fold prog_tgt. repeat fold prog_src.
             ss. rewrite LINKTGT in *. rewrite LINKSRC in *. fold skenv_link.
-            i. inv STEPTGT.
+            i. left. inv STEPTGT.
             set (Args.get_fptr args) as fptr in *.
             inv OHS.
             exploit msfind_bsim; et. i; des; clarify.

--- a/demo/mutrec/MutrecABproof.v
+++ b/demo/mutrec/MutrecABproof.v
@@ -340,7 +340,7 @@ Section LXSIM.
             { esplits; eauto. econs; eauto. econs; eauto. ss. right. unfold load_modsems.
               rewrite in_map_iff. esplits; eauto. rewrite in_app_iff; eauto. ss. auto. } }
         { i; ss. des_ifs. inv FINALTGT. }
-        i. ss. rewrite LINKSRC, LINKTGT in *. inv STEPTGT. inv MSFIND. ss.
+        i. left. ss. rewrite LINKSRC, LINKTGT in *. inv STEPTGT. inv MSFIND. ss.
         unfold load_modsems in *. des; clarify.
         { esplits; eauto.
           - left. apply plus_one. econs; eauto. econs; eauto. ss. eauto.
@@ -405,7 +405,7 @@ Section LXSIM.
             { esplits; eauto. econs 3; eauto. }
             { esplits; eauto. econs 4; eauto. } }
         { ii; ss. inv FINALTGT. des_ifs. esplits; eauto. { apply star_refl. } econs; eauto. }
-        i. ss. des_ifs.
+        i. left. ss. des_ifs.
         inv STEPTGT; ss.
         * esplits; eauto.
           { left. apply plus_one. econs 1; eauto. }
@@ -426,7 +426,7 @@ Section LXSIM.
               unsguard TGT. des; clarify; ss; esplits; eauto; econs 3; ss; eauto; econs; eauto.
             + unsguard TGT. des; clarify; ss; inv FINAL. }
         { ii; ss. inv FINALTGT. unsguard TGT. des; clarify; ss; inv FINAL. }
-        i. inv STEPTGT; ss; swap 2 3.
+        i. left. inv STEPTGT; ss; swap 2 3.
         { unsguard TGT; des; clarify; inv AT. }
         { unsguard TGT; des; clarify; inv FINAL. }
         unsguard TGT; des; clarify; ss.
@@ -531,7 +531,7 @@ Section LXSIM.
                 econs 2; eauto; esplits.
                 -- eapply plus_two with (t1 := []) (t2 := []); ss.
                    ++ econs; eauto.
-                      { 
+                      {
                         eapply lift_determinate_at; ss; des_ifs; eauto.
                         econs; eauto.
                         - ii; ss. inv H; inv H0; ss.
@@ -623,7 +623,7 @@ Section LXSIM.
             unsguard TGT. des; clarify; ss.
             - inv FINAL. ss. clarify. esplits; eauto. { apply star_refl. } econs; ss; eauto.
             - inv FINAL. ss. clarify. esplits; eauto. { apply star_refl. } econs; ss; eauto. }
-          i. ss. des_ifs. inv STEPTGT; ss.
+          i. left. ss. des_ifs. inv STEPTGT; ss.
           { unsguard TGT. des; clarify; inv AT. }
           { unsguard TGT. des; clarify; inv STEP. }
           esplits; eauto.

--- a/proof/AdequacyLocal.v
+++ b/proof/AdequacyLocal.v
@@ -806,6 +806,28 @@ Section ADQSTEP.
         { etrans; eauto. }
         { ii. etrans; try apply UNCH; ss; eauto with congruence. }
         { ii. etrans; try apply UNCH; ss; eauto with congruence. }
+      + econs 1; ss.
+        * i. desf. right.
+          inv STEPTGT.
+          { exfalso.
+            eapply ModSem.call_step_disjoint.
+            split; eauto. }
+          { hexploit STEP; eauto. i. subst.
+            split.
+            { r. unfold trace_intact. ss. eauto. }
+            esplits.
+            - econs 1.
+            - ss.
+          }
+          { exfalso.
+            eapply ModSem.step_return_disjoint.
+            split; eauto. }
+        * i. right. desf.
+          esplits. econs 3; eauto.
+        * i. exfalso.
+          inv FINALTGT.
+          eapply ModSem.step_return_disjoint.
+          split; eauto.
 
     - (* call *)
       left. right. econs; eauto. econs; eauto; cycle 1.

--- a/proof/AdequacyLocal.v
+++ b/proof/AdequacyLocal.v
@@ -708,7 +708,7 @@ Section ADQSTEP.
       { rr. ss. }
       { eapply upcast_downcast_iff; eauto. }
       { eapply upcast_downcast_iff; eauto. }
-      i; des.
+      i; des. left.
 
       exploit INITBSIM; eauto. i; des.
 
@@ -781,7 +781,7 @@ Section ADQSTEP.
       + econs 1; eauto; revgoals.
         { ii. des. clear - FINALTGT PROGRESS. inv FINALTGT. ss. ModSem.tac. }
         { ii. right. des. esplits; eauto. eapply lift_step; eauto. }
-        ii. inv STEPTGT; ModSem.tac. ss. exploit STEP; eauto. i; des_safe.
+        ii. left. inv STEPTGT; ModSem.tac. ss. exploit STEP; eauto. i; des_safe.
         eexists i1, (State ((Frame.mk ms_src st_src1) :: tail_src) _).
         esplits; eauto.
         { des.

--- a/proof/SemProps.v
+++ b/proof/SemProps.v
@@ -831,7 +831,7 @@ Proof.
   clear st_init_src_ INITSRC INITTGT. rename st_init_tgt into st. revert st.
   pcofix CIH. i. pfold. econs; eauto.
   ii. econs; eauto.
-  { ii. esplits; eauto. left. apply plus_one. ss. }
+  { ii. left. esplits; eauto. left. apply plus_one. ss. }
   { i. r in SAFESRC. specialize (SAFESRC st (star_refl _ _ _ _)). ss. }
   { ii. esplits; eauto. econs; eauto. }
 Qed.

--- a/proof/SimModSem.v
+++ b/proof/SimModSem.v
@@ -74,7 +74,12 @@ Section SIMMODSEM.
       (STAR: Star ms_src st_src0 nil st_src1 /\ ord i1 i0)
       (MLE: SimMemOh.le smo0 smo1)
       (UNCH: SimMem.unch midx smo0 smo1)
-      (BSIM: bsim i1 st_src1 st_tgt0 smo1).
+      (BSIM: bsim i1 st_src1 st_tgt0 smo1)
+  | bsim_step_pterm
+      (STEP: forall st_tgt1 tr
+               (STEPTGT: Step ms_tgt st_tgt0 tr st_tgt1),
+          tr = [Event_pterm])
+      (PROGRESS: <<STEPTGT: exists tr st_tgt1, Step ms_tgt st_tgt0 tr st_tgt1>>).
 
 
   Inductive _lxsim_pre (lxsim: idx -> state ms_src -> state ms_tgt -> SimMemOh.t -> Prop)
@@ -140,6 +145,7 @@ Section SIMMODSEM.
       inv H.
       + econs 1; eauto. i; des_safe. exploit STEP; eauto. i; des_safe. esplits; eauto.
       + econs 2; eauto.
+      + econs 3; eauto.
     - econs 3; eauto. ii; ss. exploit SU; eauto. i; des.
       esplits; eauto. ii. exploit K; eauto. i; des. esplits; eauto.
     - econs 4; eauto.
@@ -321,6 +327,13 @@ Section FACTORTARGET.
                { right. esplits; eauto; ss. eapply star_inv in P0. des; clarify; ss. eauto. }
                eauto.
         + econs 2; eauto. pclearbot. right. eapply CIH; eauto. econs; eauto.
+        + econs 3.
+          * i. inv STEPTGT.
+            { hexploit STEP; eauto. }
+            hexploit STEP; eauto. inversion 1; ss.
+          * des. hexploit STEP; eauto. i. subst.
+            exists [Event_pterm]. eexists (_, st_tgt1).
+            ss. econs 2; eauto.
       - econs 3; eauto. ii. exploit SU; eauto. i; des. esplits; eauto.
         { rr. ss. }
         i. exploit K; eauto. i; des. eexists (_, _). esplits; eauto.
@@ -346,5 +359,3 @@ Section FACTORTARGET.
   Qed.
 
 End FACTORTARGET.
-
-

--- a/proof/SimModSemLift.v
+++ b/proof/SimModSemLift.v
@@ -80,7 +80,12 @@ Section SIMMODSEM.
       (STAR: Star ms_src st_src0 nil st_src1 /\ ord i1 i0)
       (MLE: SimMemOh.le sm0 sm1)
       (UNCH: SimMem.unch midx sm0 sm1)
-      (BSIM: bsim i1 st_src1 st_tgt0 sm1).
+      (BSIM: bsim i1 st_src1 st_tgt0 sm1)
+  | bsim_step_pterm
+      (STEP: forall st_tgt1 tr
+               (STEPTGT: Step ms_tgt st_tgt0 tr st_tgt1),
+          tr = [Event_pterm])
+      (PROGRESS: <<STEPTGT: exists tr st_tgt1, Step ms_tgt st_tgt0 tr st_tgt1>>).
 
   Inductive _lxsim_pre (lxsim: idx -> state ms_src -> state ms_tgt -> SimMemOh.t -> Prop)
             (i0: idx) (st_src0: ms_src.(state)) (st_tgt0: ms_tgt.(state)) (sm0: SimMemOh.t): Prop :=
@@ -162,6 +167,7 @@ Section SIMMODSEM.
     - econs 2; ss. ii. exploit SU; eauto. i; des. inv H.
       + econs 1; eauto. i; des_safe. exploit STEP; eauto. i; des_safe. esplits; eauto.
       + econs 2; eauto.
+      + econs 3; eauto.
     - econs 3; eauto. ii; ss. exploit SU; eauto. i; des.
       esplits; eauto. ii. exploit K; eauto. i; des. esplits; eauto.
     - econs 4; eauto.
@@ -275,6 +281,8 @@ Section IMPLIES.
     - econs 2; eauto. i. hexploit1 SU0; ss. des. esplits; eauto. i. hexploit SU0; ss. intro T. inv T.
       + econs 1; eauto. i. exploit STEP; eauto. i; des_safe. esplits; et. right. pclearbot. eapply CIH; et.
       + pclearbot. econs 2; eauto.
+      + econs 3; eauto.
+
     - econs 3; et.
       ii. exploit SU0; et. i; des.
       eexists _, _. exists (SimMemOhLift.lift sm_arg).

--- a/proof/SimModSemUnified.v
+++ b/proof/SimModSemUnified.v
@@ -130,7 +130,12 @@ Section SIMMODSEM.
       (STAR: Star ms_src st_src0 nil st_src1 /\ ord i1 i0)
       (MLE: SimMemOhs.le smos0 smos1)
       (UNCH: SimMemOhs.unch midx_src smos0 smos1)
-      (BSIM: bsim i1 st_src1 st_tgt0 smos1).
+      (BSIM: bsim i1 st_src1 st_tgt0 smos1)
+  | bsim_step_pterm
+      (STEP: forall st_tgt1 tr
+               (STEPTGT: Step ms_tgt st_tgt0 tr st_tgt1),
+          tr = [Event_pterm])
+      (PROGRESS: <<STEPTGT: exists tr st_tgt1, Step ms_tgt st_tgt0 tr st_tgt1>>).
 
   Inductive _lxsim_pre (lxsim: idx -> state ms_src -> state ms_tgt -> SimMemOhs.t -> Prop)
             (i0: idx) (st_src0: ms_src.(state)) (st_tgt0: ms_tgt.(state)) (smos0: SimMemOhs.t): Prop :=
@@ -206,6 +211,7 @@ Section SIMMODSEM.
       inv H.
       + econs 1; eauto. i; des_safe. exploit STEP; eauto. i; des_safe. esplits; eauto.
       + econs 2; eauto.
+      + econs 3; eauto.
     - econs 3; eauto. ii; ss. exploit SU; eauto. i; des.
       esplits; eauto. ii. exploit K; eauto. i; des. esplits; eauto.
     - econs 4; eauto.
@@ -497,6 +503,7 @@ Proof.
         esplits; ec. pclearbot. right. eapply CIH; eauto.
       * exploit (SMSIM smos0); ec. i; des.
         econs 2; ec. pclearbot. right. eapply CIH; eauto.
+      * econs 3; eauto.
     + econs 3; eauto.
       { eapply wfwf; eauto. }
       ii. exploit SU0; eauto. i; des. exploit SMSIMPRIV; ec. i; des.


### PR DESCRIPTION
Local simulation is updated with the partial-termination (a.k.a no-behavior) case.
Paired with snu-sf/CompCertR#8
